### PR TITLE
数式やコードブロックの前後の空白チェックを追加

### DIFF
--- a/scripts/check_html.py
+++ b/scripts/check_html.py
@@ -1,6 +1,52 @@
 from bs4 import BeautifulSoup
 import os
 import warnings
+import re
+from exceptions import TitleTagError, StructureOfStatementError, SpaceError
+
+
+def title_check(soup):
+    title = soup.find_all('h2')
+    if len(title) != 1:
+        raise TitleTagError()
+
+
+def structure_check(soup):
+    subtitle = soup.find_all('h3')
+    labels = list(map(lambda x: x.extract().getText(), subtitle))
+    if labels[:4] == ['問題', '制約', '入力', '出力']:
+        i = 4
+        while i < len(labels):
+            if labels[i] != f'入力例{(i - 2) // 2}':
+                raise StructureOfStatementError()
+            if labels[i + 1] != f'出力例{(i - 2) // 2}':
+                raise StructureOfStatementError()
+
+            i += 2
+    elif labels[:5] != ['ストーリー', '問題', '制約', '入力', '出力']:
+        i = 5
+        while i < len(labels):
+            if labels[i] != f'入力例{(i - 2) // 2}':
+                raise StructureOfStatementError()
+            if labels[i + 1] != f'出力例{(i - 2) // 2}':
+                raise StructureOfStatementError()
+
+            i += 2
+    else:
+        raise StructureOfStatementError()
+
+
+def space_check(soup):
+    for tag in ['p', 'li']:
+        text = soup.find_all(tag)
+        fwd = r'(?<!<p>)(?<!<li>)(?<!。)(?<! )'
+        bwd = r'(?! )(?!</p>)(?!</li>)'
+        mid = r'(<code>.*</code>|\\\(.*\\\))'
+        exp = re.compile(f'({fwd}{mid}|{mid}{bwd})')
+        for s in map(lambda x: str(x), text):
+            res = exp.findall(s)
+            if res:
+                raise SpaceError()
 
 
 def main():
@@ -12,36 +58,11 @@ def main():
         if os.path.splitext(file)[1] != '.html':
             continue
 
-        flow_error = '問題文の流れは「問題・制約・入力・出力・入力例1・出力例1・…」であるべきです'
         with open('./HTML/' + file) as f:
             soup = BeautifulSoup(f, 'html.parser')
-            title = soup.find_all('h2')
-
-            if len(title) != 1:
-                raise Exception('タイトルのみ <h2> で囲むべきです')
-
-            subtitle = soup.find_all('h3')
-            labels = list(map(lambda x: x.extract().getText(), subtitle))
-            if labels[:4] == ['問題', '制約', '入力', '出力']:
-                i = 4
-                while i < len(labels):
-                    if labels[i] != f'入力例{(i - 2) // 2}':
-                        raise Exception(flow_error)
-                    if labels[i + 1] != f'出力例{(i - 2) // 2}':
-                        raise Exception(flow_error)
-
-                    i += 2
-            elif labels[:5] != ['ストーリー', '問題', '制約', '入力', '出力']:
-                i = 5
-                while i < len(labels):
-                    if labels[i] != f'入力例{(i - 2) // 2}':
-                        raise Exception(flow_error)
-                    if labels[i + 1] != f'出力例{(i - 2) // 2}':
-                        raise Exception(flow_error)
-
-                    i += 2
-            else:
-                raise Exception('問題文の流れは「問題・制約・入力・出力・入力例1・出力例1・…」であるべきです')
+            title_check(soup)
+            structure_check(soup)
+            space_check(soup)
 
 
 if __name__ == '__main__':

--- a/scripts/exceptions.py
+++ b/scripts/exceptions.py
@@ -1,0 +1,22 @@
+class TitleTagError(Exception):
+    def __init__(self, msg='タイトルのみ<h2>で囲むべきです'):
+        self._msg = msg
+
+    def __str__(self):
+        return self._msg
+
+
+class StructureOfStatementError(Exception):
+    def __init__(self, msg='問題文の流れは「問題・制約・入力・出力・入力例1・出力例1・…」であるべきです'):
+        self._msg = msg
+
+    def __str__(self):
+        return self._msg
+
+
+class SpaceError(Exception):
+    def __init__(self, msg=r'\( \) や <code> </code> の前後には空白を入れるべきです'):
+        self._msg = msg
+
+    def __str__(self):
+        return self._msg


### PR DESCRIPTION
## 担当

- [ ] Writer
- [ ] Tester
- [ ] Validation

## 確認

- [ ] [作問用チェックリスト](https://yukicoder.me/wiki/problem_checklist)を確認しました
- [ ] GitHub Actions のテストは pass しました
- [ ] 問題文のサンプルをテストケースに入れました
- [ ] サンプルが先頭に来るようなファイル名にしました
- [ ] テストケースの入力ファイルの拡張子は `*.in` です

## やったこと

